### PR TITLE
Revert temporary libmaria update commit

### DIFF
--- a/ports/libmariadb/arm64.patch
+++ b/ports/libmariadb/arm64.patch
@@ -1,0 +1,15 @@
+diff --git a/libmariadb/CMakeLists.txt b/libmariadb/CMakeLists.txt
+index 640a35bea..6c8d93250 100755
+--- a/libmariadb/CMakeLists.txt
++++ b/libmariadb/CMakeLists.txt
+@@ -410,10 +410,6 @@ TARGET_LINK_LIBRARIES(libmariadb LINK_PRIVATE ${SYSTEM_LIBS})
+
+ SIGN_TARGET(libmariadb)
+
+-IF(CMAKE_SIZEOF_VOID_P EQUAL 8 AND MSVC)
+-  SET_TARGET_PROPERTIES(mariadbclient PROPERTIES STATIC_LIBRARY_FLAGS "/machine:x64")
+-ENDIF()
+-
+ IF(CMAKE_SYSTEM_NAME MATCHES "Linux" OR
+    CMAKE_SYSTEM_NAME MATCHES "kFreeBSD" OR
+    CMAKE_SYSTEM_NAME MATCHES "GNU")

--- a/ports/libmariadb/export-cmake-targets.patch
+++ b/ports/libmariadb/export-cmake-targets.patch
@@ -1,8 +1,8 @@
 diff --git a/libmariadb/CMakeLists.txt b/libmariadb/CMakeLists.txt
-index d4e07f7..4823858 100644
+index c109a20..e1fa3f1 100644
 --- a/libmariadb/CMakeLists.txt
 +++ b/libmariadb/CMakeLists.txt
-@@ -423,6 +423,7 @@ ELSE()
+@@ -405,6 +405,7 @@ ELSE()
    ADD_LIBRARY(libmariadb ${libmariadb_RC} ${MARIADB_OBJECTS} mariadbclient.def)
    SET_TARGET_PROPERTIES(libmariadb PROPERTIES LINKER_LANGUAGE C)
  ENDIF()
@@ -10,20 +10,19 @@ index d4e07f7..4823858 100644
  
  TARGET_LINK_LIBRARIES(libmariadb LINK_PRIVATE ${SYSTEM_LIBS})
  
-@@ -472,13 +473,32 @@ ENDIF()
+@@ -453,13 +454,30 @@ ENDIF()
  
  INSTALL(TARGETS mariadbclient
            COMPONENT Development
 +          EXPORT unofficial-libmariadb-targets
            LIBRARY DESTINATION lib)
- IF(WIN32)
  INSTALL(TARGETS libmariadb
-         COMPONENT SharedLibraries
+           COMPONENT SharedLibraries
 +        EXPORT unofficial-libmariadb-targets
          RUNTIME DESTINATION bin
          LIBRARY DESTINATION lib
          ARCHIVE DESTINATION lib)
-+
+ 
 +install(EXPORT unofficial-libmariadb-targets
 +    NAMESPACE unofficial::
 +    DESTINATION share/unofficial-libmariadb
@@ -39,7 +38,6 @@ index d4e07f7..4823858 100644
 +]])
 +configure_file("${CMAKE_CURRENT_BINARY_DIR}/unofficial-libmariadb-config.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/unofficial-libmariadb-config.cmake" @ONLY)
 +install(FILES ${CMAKE_CURRENT_BINARY_DIR}/unofficial-libmariadb-config.cmake DESTINATION share/unofficial-libmariadb)
-+        
- ELSE()
- # in cmake 3.12+ we can use
- #INSTALL(TARGETS libmariadb LIBRARY DESTINATION ${INSTALL_LIBDIR}
+ 
+ IF(0)
+    # On Windows, install PDB

--- a/ports/libmariadb/fix-InstallPath.patch
+++ b/ports/libmariadb/fix-InstallPath.patch
@@ -12,10 +12,10 @@ index a82dbb7..e9005fa 100644
  /* mysqld compile time options */
  #ifndef MYSQL_CHARSET
 diff --git a/libmariadb/CMakeLists.txt b/libmariadb/CMakeLists.txt
-index 7faf827..d4e07f7 100644
+index bcfd4de..c109a20 100644
 --- a/libmariadb/CMakeLists.txt
 +++ b/libmariadb/CMakeLists.txt
-@@ -417,10 +417,10 @@ ADD_LIBRARY(mariadbclient STATIC  ${MARIADB_OBJECTS} ${EMPTY_FILE})
+@@ -398,10 +398,10 @@ ADD_LIBRARY(mariadbclient STATIC  ${MARIADB_OBJECTS} ${EMPTY_FILE})
  TARGET_LINK_LIBRARIES(mariadbclient ${SYSTEM_LIBS})
  
  IF(UNIX)
@@ -28,25 +28,19 @@ index 7faf827..d4e07f7 100644
    SET_TARGET_PROPERTIES(libmariadb PROPERTIES LINKER_LANGUAGE C)
  ENDIF()
  
-@@ -472,11 +472,13 @@ ENDIF()
+@@ -453,13 +453,15 @@ ENDIF()
  
  INSTALL(TARGETS mariadbclient
            COMPONENT Development
 -          DESTINATION ${INSTALL_LIBDIR})
 +          LIBRARY DESTINATION lib)
- IF(WIN32)
  INSTALL(TARGETS libmariadb
-         COMPONENT SharedLibraries
+           COMPONENT SharedLibraries
 -        DESTINATION ${INSTALL_LIBDIR})
 +        RUNTIME DESTINATION bin
 +        LIBRARY DESTINATION lib
 +        ARCHIVE DESTINATION lib)
- ELSE()
- # in cmake 3.12+ we can use
- #INSTALL(TARGETS libmariadb LIBRARY DESTINATION ${INSTALL_LIBDIR}
-@@ -488,7 +490,7 @@ INSTALL(TARGETS libmariadb LIBRARY DESTINATION ${INSTALL_LIBDIR}
-         COMPONENT Development NAMELINK_ONLY)
- ENDIF()
+ 
  
 -IF(MSVC)
 +IF(0)
@@ -54,10 +48,10 @@ index 7faf827..d4e07f7 100644
     INSTALL(FILES $<TARGET_PDB_FILE:libmariadb> DESTINATION "${INSTALL_LIBDIR}"
             CONFIGURATIONS Debug RelWithDebInfo
 diff --git a/mariadb_config/mariadb_config.c.in b/mariadb_config/mariadb_config.c.in
-index 36c0117..4184e4b 100644
+index 5574943..fc1ca7c 100644
 --- a/mariadb_config/mariadb_config.c.in
 +++ b/mariadb_config/mariadb_config.c.in
-@@ -225,7 +225,7 @@ end:
+@@ -210,7 +210,7 @@ end:
    }
    if (!p || !p[0])
    {

--- a/ports/libmariadb/no-extra-static-lib.patch
+++ b/ports/libmariadb/no-extra-static-lib.patch
@@ -1,8 +1,8 @@
 diff --git a/libmariadb/CMakeLists.txt b/libmariadb/CMakeLists.txt
-index 4823858..018101f 100644
+index 39fa709..a726a6d 100644
 --- a/libmariadb/CMakeLists.txt
 +++ b/libmariadb/CMakeLists.txt
-@@ -471,10 +471,15 @@ IF(NOT WIN32)
+@@ -455,10 +455,14 @@ IF(NOT WIN32)
    SET_TARGET_PROPERTIES(mariadbclient PROPERTIES OUTPUT_NAME "${LIBMARIADB_STATIC_NAME}")
  ENDIF()
  
@@ -14,7 +14,6 @@ index 4823858..018101f 100644
 +else()
 +  set_target_properties(mariadbclient PROPERTIES EXCLUDE_FROM_ALL 1)
 +endif()
-+          
- IF(WIN32)
  INSTALL(TARGETS libmariadb
-         COMPONENT SharedLibraries
+           COMPONENT SharedLibraries
+         EXPORT unofficial-libmariadb-targets

--- a/ports/libmariadb/pkgconfig.patch
+++ b/ports/libmariadb/pkgconfig.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a109325..b56403c 100644
+index 0be0fb1..33565f5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -420,7 +420,7 @@ ENDIF()
+@@ -393,7 +393,7 @@ ENDIF()
  INCLUDE(${CC_SOURCE_DIR}/plugins/CMakeLists.txt)
  ADD_SUBDIRECTORY(include)
  ADD_SUBDIRECTORY(libmariadb)
@@ -12,7 +12,7 @@ index a109325..b56403c 100644
  ENDIF()
  
 diff --git a/mariadb_config/CMakeLists.txt b/mariadb_config/CMakeLists.txt
-index 743ae52..482a4cf 100644
+index 70e619b..7a22fa1 100644
 --- a/mariadb_config/CMakeLists.txt
 +++ b/mariadb_config/CMakeLists.txt
 @@ -30,6 +30,15 @@ IF(${rllength} GREATER 0)
@@ -41,7 +41,7 @@ index 743ae52..482a4cf 100644
  IF(CMAKE_SYSTEM_NAME MATCHES AIX)
 @@ -61,6 +71,7 @@ ENDIF()
  INSTALL(TARGETS mariadb_config
-         DESTINATION "${INSTALL_BINDIR}"
+         DESTINATION "bin"
          COMPONENT Development)
 +endif()
  

--- a/ports/libmariadb/portfile.cmake
+++ b/ports/libmariadb/portfile.cmake
@@ -9,10 +9,11 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mariadb-corporation/mariadb-connector-c
-    REF 5e94e7c27ffad7e76665b1333a67975316b9c3c2 # v3.3.1
-    SHA512 0f740f88f64037990bf9d4593574b147ee02adb1fbbeb03c0dec745f0ee27d7cf03417dd09546ab70e16b4465622b8567864dbb243de0a3a7ffaebe313f7c231
-    HEAD_REF 3.3
+    REF b2bb1b213c79169b7c994a99f21f47f11be465d4 # v3.1.15
+    SHA512 51ebd2e9fd505eebc7691c60fe0b86cfc5368f8b370fba6c3ec8f5514319ef1e0de4910ad5e093cd7d5e5c7782120e22e8c85c94af9389fa4e240cedf012d755
+    HEAD_REF 3.1
     PATCHES
+        arm64.patch
         md.patch
         disable-test-build.patch
         fix-InstallPath.patch

--- a/ports/libmariadb/vcpkg.json
+++ b/ports/libmariadb/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libmariadb",
-  "version-semver": "3.3.1",
+  "version-semver": "3.1.15",
+  "port-version": 1,
   "description": "MariaDB Connector/C is used to connect C/C++ applications to MariaDB and MySQL databases",
   "homepage": "https://github.com/MariaDB/mariadb-connector-c",
   "license": "LGPL-2.1-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3821,8 +3821,8 @@
       "port-version": 1
     },
     "libmariadb": {
-      "baseline": "3.3.1",
-      "port-version": 0
+      "baseline": "3.1.15",
+      "port-version": 1
     },
     "libmaxminddb": {
       "baseline": "1.4.3",

--- a/versions/l-/libmariadb.json
+++ b/versions/l-/libmariadb.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "ab286c57741848d9bb9a806ad29f5366283af520",
-      "version-semver": "3.3.1",
-      "port-version": 0
-    },
-    {
       "git-tree": "06122c8b00cc582d3ee36072fcbd03fa9385f238",
       "version-semver": "3.1.15",
       "port-version": 1


### PR DESCRIPTION
This reverts commit 581099d541ec960db5c2a8efe4639f1e2e25de60.

Correction of issue https://github.com/opentibiabr/canary/issues/494

**Describe the pull request**

- #### What does your PR fix?
  This PR reverts the libmaria update commit which was breaking the Dockerfile canary build.